### PR TITLE
Update ta-cmi requirement to version 3.6.2

### DIFF
--- a/custom_components/ta_cmi/manifest.json
+++ b/custom_components/ta_cmi/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/DeerMaximum/Technische-Alternative-CMI",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/DeerMaximum/Technische-Alternative-CMI/issues",
-    "requirements": ["ta-cmi==3.6.0"],
+    "requirements": ["ta-cmi==3.6.2"],
     "version": "1.12.1"
 }


### PR DESCRIPTION
I just updated the manifest.json to require ta-cmi==3.6.2 as well, so Home Assistant actually pulls your new version. Tested this on my instance, works fine for me!